### PR TITLE
Add layer titles and vertically center node stacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,71 +8,81 @@
   <body>
     <h1>Neuralt nätverk för bevattning</h1>
 
+    <div id="layer-titles">
+      <h2 class="layer-title">Input lager</h2>
+      <h2 class="layer-title">Dolt lager</h2>
+      <h2 class="layer-title">Output lager</h2>
+    </div>
+
     <div id="network-container">
       <!-- ---------- Indatalager ---------- -->
       <div id="input-layer" class="layer">
-        <div class="input-node" id="input0">
-          <label
-            >Jordfuktighet (%)
-            <input type="number" id="moisture" value="30" step="1" />
-          </label>
-        </div>
-        <div class="input-node" id="input1">
-          <label
-            >Lufttemperatur (°C)
-            <input type="number" id="temperature" value="20" step="1" />
-          </label>
+        <div class="node-stack">
+          <div class="input-node" id="input0">
+            <label
+              >Jordfuktighet (%)
+              <input type="number" id="moisture" value="30" step="1" />
+            </label>
+          </div>
+          <div class="input-node" id="input1">
+            <label
+              >Lufttemperatur (°C)
+              <input type="number" id="temperature" value="20" step="1" />
+            </label>
+          </div>
         </div>
       </div>
 
       <!-- ---------- Dolt lager ---------- -->
       <div id="hidden-layer" class="layer">
-        <div class="hidden-node" id="hidden0">
-          <div class="bias-label bias-hidden" id="bias-h0">b=-0.82</div>
-          <div class="node-part pre" id="pre-h0">?</div>
-          <div class="node-part relu">
-            <svg viewBox="0 0 40 40">
-              <path
-                d="M5 20H20L35 5"
-                stroke="#fff"
-                stroke-width="4"
-                fill="none"
-              />
-            </svg>
+        <div class="node-stack">
+          <div class="hidden-node" id="hidden0">
+            <div class="bias-label bias-hidden" id="bias-h0">b=-0.82</div>
+            <div class="node-part pre" id="pre-h0">?</div>
+            <div class="node-part relu">
+              <svg viewBox="0 0 40 40">
+                <path
+                  d="M5 20H20L35 5"
+                  stroke="#fff"
+                  stroke-width="4"
+                  fill="none"
+                />
+              </svg>
+            </div>
+            <div class="node-part post" id="post-h0">?</div>
           </div>
-          <div class="node-part post" id="post-h0">?</div>
-        </div>
 
-        <div class="hidden-node" id="hidden1">
-          <div class="bias-label bias-hidden" id="bias-h1">b=0.71</div>
-          <div class="node-part pre" id="pre-h1">?</div>
-          <div class="node-part relu">
-            <svg viewBox="0 0 40 40">
-              <path
-                d="M5 20H20L35 5"
-                stroke="#fff"
-                stroke-width="4"
-                fill="none"
-              />
-            </svg>
+          <div class="hidden-node" id="hidden1">
+            <div class="bias-label bias-hidden" id="bias-h1">b=0.71</div>
+            <div class="node-part pre" id="pre-h1">?</div>
+            <div class="node-part relu">
+              <svg viewBox="0 0 40 40">
+                <path
+                  d="M5 20H20L35 5"
+                  stroke="#fff"
+                  stroke-width="4"
+                  fill="none"
+                />
+              </svg>
+            </div>
+            <div class="node-part post" id="post-h1">?</div>
           </div>
-          <div class="node-part post" id="post-h1">?</div>
-        </div>
 
-        <div class="hidden-node" id="hidden2">
-          <div class="bias-label bias-hidden" id="bias-h2">b=0.35</div>
-          <div class="node-part pre" id="pre-h2">?</div>
-          <div class="node-part relu">
-            <svg viewBox="0 0 40 40">
-              <path
-                d="M5 20H20L35 5"
-                stroke="#fff"
-                stroke-width="4"
-                fill="none"
-              />
-            </svg>
+          <div class="hidden-node" id="hidden2">
+            <div class="bias-label bias-hidden" id="bias-h2">b=0.35</div>
+            <div class="node-part pre" id="pre-h2">?</div>
+            <div class="node-part relu">
+              <svg viewBox="0 0 40 40">
+                <path
+                  d="M5 20H20L35 5"
+                  stroke="#fff"
+                  stroke-width="4"
+                  fill="none"
+                />
+              </svg>
+            </div>
+            <div class="node-part post" id="post-h2">?</div>
           </div>
-          <div class="node-part post" id="post-h2">?</div>
         </div>
 
         <div class="controls">
@@ -89,9 +99,11 @@
 
       <!-- ---------- Outputlager ---------- -->
       <div id="output-layer" class="layer">
-        <div class="output-node" id="output-node">
-          <div class="bias-label bias-output" id="bias-o">b=0.91</div>
-          <div id="output-prob">?</div>
+        <div class="node-stack">
+          <div class="output-node" id="output-node">
+            <div class="bias-label bias-output" id="bias-o">b=0.91</div>
+            <div id="output-prob">?</div>
+          </div>
         </div>
         <div id="prediction-text">Bevattning startas: ?</div>
 

--- a/styles.css
+++ b/styles.css
@@ -17,12 +17,27 @@ h1 {
 }
 
 /* ---------- Lagerlayout ---------- */
-#network-container {
+#layer-titles {
   display: flex;
   justify-content: center;
   align-items: center;
   gap: 180px;
-  margin: 40px auto;
+  margin: 24px auto 0;
+  max-width: 1500px;
+}
+
+.layer-title {
+  font-size: 1.1em;
+  font-weight: 700;
+  text-align: center;
+}
+
+#network-container {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  gap: 180px;
+  margin: 30px auto 40px;
   position: relative;
   max-width: 1500px;
 }
@@ -31,8 +46,17 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 34px;
+  gap: 24px;
   position: relative;
+  height: 100%;
+}
+
+.node-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 34px;
+  margin: auto 0;
 }
 
 /* ---------- SVG-ytan för linjer ---------- */


### PR DESCRIPTION
## Summary
- add layer titles above the network to describe input, hidden, and output layers
- wrap each layer's nodes in a dedicated stack to vertically center them across the layout
- adjust styling to keep supporting controls below the centered nodes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e381c47504832b983f8af0306f8720