### PR TITLE
Justera nodernas vertikala positioner

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -27,12 +27,13 @@ h1 {
 #network-container {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   gap: clamp(80px, 12vw, 180px);
   margin: 30px auto 40px;
   position: relative;
   max-width: 1500px;
   padding: 20px 10px;
+  min-height: 460px;
 }
 
 .layer {
@@ -42,14 +43,30 @@ h1 {
   justify-content: center;
   gap: 24px;
   position: relative;
-  height: 100%;
+  flex: 1;
 }
 
 .node-stack {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 34px;
+  height: 100%;
+}
+
+#input-layer .node-stack {
+  justify-content: space-between;
+  padding: 60px 0;
+}
+
+#hidden-layer .node-stack {
+  justify-content: center;
+}
+
+#output-layer .node-stack {
+  justify-content: center;
+  padding-top: 40px;
 }
 
 /* ---------- SVG-ytan för linjer ---------- */


### PR DESCRIPTION
## Summary
- justera containern och noderna så att lagren får en enhetlig höjd
- centrera det dolda lagrets mittnod och flytta input- och output-noder mot den tänkta horisontella linjen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e390e46eec832b9b4891e2513e3eb4