### PR TITLE
Align input nodes with hidden layer

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,6 +41,17 @@ function edgeMid(el, side) {
   return { x, y };
 }
 
+/***** Justera indatanoder *****/
+function alignInputNodes() {
+  if (!hiddenEls.length || inputEls.length < 2) return;
+  const topTarget = edgeMid(hiddenEls[0], 'left').y;
+  const bottomTarget = edgeMid(hiddenEls[hiddenEls.length - 1], 'left').y;
+  const currentTop = edgeMid(inputEls[0], 'right').y;
+  const currentBottom = edgeMid(inputEls[inputEls.length - 1], 'right').y;
+  inputEls[0].style.transform = `translateY(${topTarget - currentTop}px)`;
+  inputEls[1].style.transform = `translateY(${bottomTarget - currentBottom}px)`;
+}
+
 /***** Rita linje + etikett *****/
 function makeLine(x1, y1, x2, y2, label) {
   const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
@@ -199,6 +210,7 @@ document.getElementById('show-ho').addEventListener('change', (e) =>
 /***** Init *****/
 function refresh() {
   window.requestAnimationFrame(() => {
+    alignInputNodes();
     buildConnections();
     updateBiasLabels();
   });

--- a/styles.css
+++ b/styles.css
@@ -56,8 +56,8 @@ h1 {
 }
 
 #input-layer .node-stack {
-  justify-content: space-between;
-  padding: 60px 0;
+  justify-content: center;
+  padding: 0;
 }
 
 #hidden-layer .node-stack {


### PR DESCRIPTION
## Summary
- center the input layer stack to allow precise repositioning
- add runtime alignment logic so each input node lines up with the hidden nodes
- refresh SVG connections after adjusting node positions

## Testing
- Manual QA: Viewed index.html in browser

------
https://chatgpt.com/codex/tasks/task_e_68e39256233c832bb086dda7a895fab1