### PR TITLE
Visa råa utdatavärden i utmatningslagret

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
       <!-- ---------- Outputlager ---------- -->
       <div id="output-layer" class="layer">
         <h2 class="layer-title">Utmatningslager</h2>
+        <p class="layer-info">Bevattningen startas om värdet är positivt (&gt;0)</p>
         <div class="node-stack">
           <div class="output-node" id="output-node">
             <div class="bias-label bias-output" id="bias-o">b=?</div>

--- a/script.js
+++ b/script.js
@@ -30,7 +30,6 @@ let currentHOVisible = false;
 
 /***** Utility-funktioner *****/
 const round2 = (x) => Math.round(x * 100) / 100;
-const logistic = (x) => 1 / (1 + Math.exp(-x));
 
 /* Returnera mitten på vänster/höger kant rel. container */
 function edgeMid(el, side) {
@@ -189,10 +188,9 @@ document.getElementById('calc-hidden').addEventListener('click', () => {
 
 document.getElementById('calc-output').addEventListener('click', () => {
   const net = hiddenOut.reduce((s, h, j) => s + h * W_HO[j], 0) + B_O;
-  const p = logistic(net);
-  outputProb.textContent = round2(p);
+  outputProb.textContent = round2(net);
   document.getElementById('prediction-text').textContent = `Bevattning startas: ${
-    p >= 0.5 ? 'ja' : 'nej'
+    net > 0 ? 'ja' : 'nej'
   }`;
 });
 

--- a/styles.css
+++ b/styles.css
@@ -24,6 +24,13 @@ h1 {
   margin: 0 0 18px;
 }
 
+.layer-info {
+  margin: -10px 0 12px;
+  font-size: 0.9em;
+  text-align: center;
+  color: #555;
+}
+
 #network-container {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- visa det råa nettopvärdet i utmatningslagrets nod istället för logistiskt sannolikhetsvärde
- uppdatera beslutet om bevattning så att det triggas när nettopvärdet är positivt
- lägg till förklarande text och styling för utmatningslagret

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e409e38388832b9101785976959785