### PR TITLE
Adjust weight labels to sit above connections

### DIFF
--- a/script.js
+++ b/script.js
@@ -118,7 +118,7 @@ function buildConnections() {
           {
             labelRatio: 0.2,
             verticalOffset: 0,
-            normalOffset: 12,
+            normalOffset: -12,
             align: true
           }
         )
@@ -127,7 +127,16 @@ function buildConnections() {
   }
   for (let j = 0; j < 3; j += 1) {
     hoLines.push(
-      makeLine(hidR[j].x, hidR[j].y, outL.x, outL.y, W_HO[j].toFixed(2))
+      makeLine(
+        hidR[j].x,
+        hidR[j].y,
+        outL.x,
+        outL.y,
+        W_HO[j].toFixed(2),
+        {
+          normalOffset: -10
+        }
+      )
     );
   }
   showIH(currentIHSelection);


### PR DESCRIPTION
## Summary
- flip the perpendicular offset for input-to-hidden connection labels so they appear above the lines
- offset hidden-to-output labels away from the connectors to keep them above as well

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e40dded8a0832b8be07878c23e456f