### PR TITLE
Justera positionen för viktetiketter

### DIFF
--- a/script.js
+++ b/script.js
@@ -116,9 +116,9 @@ function buildConnections() {
           hidL[j].y,
           W_IH[i][j].toFixed(2),
           {
-            labelRatio: 0.2,
-            verticalOffset: 0,
-            normalOffset: -12,
+            labelRatio: 1 / 3,
+            verticalOffset: -2,
+            normalOffset: -6,
             align: true
           }
         )


### PR DESCRIPTION
## Summary
- flytta viktetiketter på indata-till-dolt-lager-kopplingar närmare linjerna
- placera etiketterna en tredjedel av sträckan från indatanoden för tydligare koppling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e40fbd914c832bb162834f3e3149af