### PR TITLE
Align HO weight labels with connections

### DIFF
--- a/script.js
+++ b/script.js
@@ -134,7 +134,10 @@ function buildConnections() {
         outL.y,
         W_HO[j].toFixed(2),
         {
-          normalOffset: -10
+          labelRatio: 2 / 3,
+          verticalOffset: -2,
+          normalOffset: -6,
+          align: true
         }
       )
     );


### PR DESCRIPTION
## Summary
- align the hidden-to-output weight labels so they sit above and parallel to their connection lines

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e411f33114832bac8d989e31f0e51f