### PR TITLE
Add toggle to control auto training animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,10 @@
             Batch-storlek
             <input type="number" id="batch-input" min="1" value="10" />
           </label>
+          <label class="output-wrapper">
+            <input type="checkbox" id="animate-training" checked />
+            <span>Visa animationer</span>
+          </label>
           <button id="auto-train-btn">Automatisk träning</button>
         </div>
         <button id="reset-weights-btn" class="secondary">

--- a/script.js
+++ b/script.js
@@ -154,6 +154,7 @@ const manualTrainingBtn = document.getElementById('manual-training-btn');
 const autoTrainBtn = document.getElementById('auto-train-btn');
 const epochsInput = document.getElementById('epochs-input');
 const batchInput = document.getElementById('batch-input');
+const animateTrainingCheckbox = document.getElementById('animate-training');
 const resetBtn = document.getElementById('reset-weights-btn');
 const toggleTrainingBtn = document.getElementById('toggle-training-table');
 const trainingTableContainer = document.getElementById('training-table-container');
@@ -176,6 +177,7 @@ let manualAnimating = false;
 let autoRunning = false;
 let storedIHSelection = 'none';
 let storedHOVisible = false;
+let autoAnimationEnabled = animateTrainingCheckbox.checked;
 
 /***** Utility-funktioner *****/
 const round2 = (x) => Math.round(x * 100) / 100;
@@ -261,6 +263,10 @@ function updateControlStates() {
   epochsInput.disabled = autoRunning;
   batchInput.disabled = autoRunning;
 }
+
+animateTrainingCheckbox.addEventListener('change', () => {
+  autoAnimationEnabled = animateTrainingCheckbox.checked;
+});
 
 function forwardPassCore(x, p = params) {
   const preHidden = [];
@@ -790,7 +796,9 @@ async function runAutoTraining() {
       updateWeightLabels();
       epochLossSum += grads.loss * grads.batchSize;
       sampleCount += grads.batchSize;
-      await wait(30);
+      if (autoAnimationEnabled) {
+        await wait(30);
+      }
     }
     const avgLoss = sampleCount ? epochLossSum / sampleCount : 0;
     autoStatus.textContent = `Epok ${epoch}/${epochs} klar – medelfel: ${round2(


### PR DESCRIPTION
## Summary
- add an animation toggle checkbox to the automatic training controls that is enabled by default
- persist the toggle state in script.js and skip the batch delay when animations are disabled

## Testing
- Manual verification (Playwright automation) to compare durations with and without the animation toggle

------
https://chatgpt.com/codex/tasks/task_e_68e429212f50832b9e18d16640ff8a51