### PR TITLE
Adjust bias labels and weight text layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         <h2 class="layer-title">Dolt lager</h2>
         <div class="node-stack">
           <div class="hidden-node" id="hidden0">
-            <div class="bias-label bias-hidden" id="bias-h0">b=?</div>
+            <div class="bias-label bias-hidden" id="bias-h0">?</div>
             <div class="node-part pre" id="pre-h0">?</div>
             <div class="node-part relu">
               <svg viewBox="0 0 40 40">
@@ -56,7 +56,7 @@
           </div>
 
           <div class="hidden-node" id="hidden1">
-            <div class="bias-label bias-hidden" id="bias-h1">b=?</div>
+            <div class="bias-label bias-hidden" id="bias-h1">?</div>
             <div class="node-part pre" id="pre-h1">?</div>
             <div class="node-part relu">
               <svg viewBox="0 0 40 40">
@@ -72,7 +72,7 @@
           </div>
 
           <div class="hidden-node" id="hidden2">
-            <div class="bias-label bias-hidden" id="bias-h2">b=?</div>
+            <div class="bias-label bias-hidden" id="bias-h2">?</div>
             <div class="node-part pre" id="pre-h2">?</div>
             <div class="node-part relu">
               <svg viewBox="0 0 40 40">
@@ -107,7 +107,7 @@
         <div class="node-stack">
           <div class="output-wrapper">
             <div class="output-node" id="output-node">
-              <div class="bias-label bias-output" id="bias-o">b=?</div>
+              <div class="bias-label bias-output" id="bias-o">?</div>
               <div id="output-prob">?</div>
             </div>
             <button id="backprop-btn" class="secondary hidden">

--- a/script.js
+++ b/script.js
@@ -450,7 +450,7 @@ function buildConnections() {
       outL.y,
       params.W_HO[j].toFixed(2),
       {
-        labelRatio: 2 / 3,
+        labelRatio: 1 / 3,
         verticalOffset: -2,
         normalOffset: -6,
         align: true
@@ -463,11 +463,16 @@ function buildConnections() {
   toggleHO(currentHOVisible);
 }
 
+function formatBias(value) {
+  const formatted = value.toFixed(2);
+  return value >= 0 ? `+${formatted}` : formatted;
+}
+
 function updateBiasLabels() {
   hiddenBiasEls.forEach((el, idx) => {
-    el.textContent = `b=${params.B_H[idx].toFixed(2)}`;
+    el.textContent = formatBias(params.B_H[idx]);
   });
-  outputBiasEl.textContent = `b=${params.B_O.toFixed(2)}`;
+  outputBiasEl.textContent = formatBias(params.B_O);
 }
 
 function updateWeightLabels() {
@@ -714,7 +719,7 @@ async function handleBackprop() {
   );
   const lr = LEARNING_RATE_MANUAL;
 
-  outputBiasEl.textContent = `b=${params.B_O.toFixed(2)}`;
+  outputBiasEl.textContent = formatBias(params.B_O);
   highlightBiasLabel(outputBiasEl, 900);
   params.B_O -= lr * grads.B_O;
   updateBiasLabels();


### PR DESCRIPTION
## Summary
- move the hidden-to-output weight labels closer to the hidden layer for improved readability
- update the bias labels to drop the "b=" prefix and show an explicit plus sign for positive values

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4a3489c60832b859aa63872131e67