### PR TITLE
Adjust manual training UI workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,17 +123,24 @@
 
     <section id="manual-training-panel">
       <div id="manual-controls" class="manual-controls hidden">
-        <div class="manual-controls-buttons">
-          <button id="load-next-example" class="accent-button">
-            Ladda nästa exempel
-          </button>
-          <button id="backprop-btn" class="secondary hidden">
-            Bakåtpropagering
-          </button>
-        </div>
-        <div class="manual-controls-info">
-          <div id="manual-example-info"></div>
-          <div id="manual-feedback"></div>
+        <div class="manual-grid">
+          <div class="manual-cell manual-left">
+            <button id="load-next-example" class="manual-btn manual-btn-next">
+              Ladda nästa exempel
+            </button>
+          </div>
+          <div class="manual-cell manual-center">
+            <div id="manual-example-info"></div>
+          </div>
+          <div class="manual-cell manual-right">
+            <button
+              id="backprop-btn"
+              class="manual-btn manual-btn-backprop hidden"
+            >
+              Bakåtpropagering
+            </button>
+            <div id="manual-feedback"></div>
+          </div>
         </div>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -67,44 +67,47 @@ h1 {
 }
 
 #manual-training-panel {
-  max-width: 1100px;
-  margin: 0 auto 30px;
-  background: #f4f6f9;
-  padding: 20px;
-  min-height: 120px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 16px;
+  max-width: 1500px;
+  margin: 0 auto 26px;
+  padding: 0 24px 10px;
 }
 
 .manual-controls {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-  text-align: center;
   width: 100%;
 }
 
-.manual-controls-buttons {
-  display: flex;
-  gap: 12px;
-  justify-content: center;
-  flex-wrap: wrap;
+.manual-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(20px, 5vw, 60px);
+  align-items: flex-start;
 }
 
-.manual-controls-info {
+.manual-cell {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
+}
+
+.manual-left {
+  align-items: flex-start;
+}
+
+.manual-center {
   align-items: center;
+  text-align: center;
+}
+
+.manual-right {
+  align-items: flex-end;
+  text-align: right;
 }
 
 .manual-controls #manual-example-info {
-  font-size: 0.9em;
+  font-size: 0.95em;
   color: #2c3e50;
   min-height: 20px;
+  max-width: 320px;
 }
 
 #input-layer .node-stack {
@@ -228,6 +231,10 @@ h1 {
   left: 0;
 }
 
+.bias-update {
+  color: #e74c3c !important;
+}
+
 /* ---------- Kontroller ---------- */
 .controls {
   display: flex;
@@ -252,6 +259,10 @@ button:hover {
   background: #2980b9;
 }
 
+button:disabled {
+  cursor: not-allowed;
+}
+
 .accent-button {
   background: #27ae60;
 }
@@ -266,6 +277,37 @@ button:hover {
 
 .secondary:hover {
   background: #7f8c8d;
+}
+
+.manual-btn {
+  min-width: 220px;
+  font-weight: 600;
+}
+
+.manual-btn-next {
+  background: #2ecc71;
+}
+
+.manual-btn-next:hover {
+  background: #27ae60;
+}
+
+.manual-btn-next:disabled {
+  background: #b8e5c6;
+  color: #f9fffa;
+}
+
+.manual-btn-backprop {
+  background: #e74c3c;
+}
+
+.manual-btn-backprop:hover {
+  background: #c0392b;
+}
+
+.manual-btn-backprop:disabled {
+  background: #f3a9a1;
+  color: #fff7f6;
 }
 
 select,
@@ -426,13 +468,13 @@ table.data-table tbody tr:hover {
 
 @keyframes updateGlow {
   0% {
-    box-shadow: 0 0 0 rgba(243, 156, 18, 0);
+    box-shadow: 0 0 0 rgba(231, 76, 60, 0);
   }
   50% {
-    box-shadow: 0 0 20px rgba(243, 156, 18, 0.7);
+    box-shadow: 0 0 22px rgba(231, 76, 60, 0.75);
   }
   100% {
-    box-shadow: 0 0 0 rgba(243, 156, 18, 0);
+    box-shadow: 0 0 0 rgba(231, 76, 60, 0);
   }
 }
 
@@ -447,11 +489,11 @@ table.data-table tbody tr:hover {
 }
 
 .svg-update {
-  stroke: #f39c12 !important;
+  stroke: #e74c3c !important;
   stroke-width: 3 !important;
 }
 
 .svg-update-text {
-  fill: #f39c12 !important;
+  fill: #e74c3c !important;
   font-weight: 700;
 }


### PR DESCRIPTION
## Summary
- place the manual training buttons beneath the network so the next-example control sits under the input layer and the backprop control under the output layer
- tweak the manual training flow to disable and restyle buttons as examples move through forward and backward passes while showing the evaluation under the red backprop button
- highlight weights, biases, and connection labels in red during backpropagation updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4a99e3260832bb7b745e162c8958c