### PR TITLE
Omstrukturera träningspanelen och datautvärdering

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,37 +145,33 @@
       <h2>Träningsområde</h2>
 
       <div class="training-actions">
-        <button id="toggle-training-table">Visa träningsdata</button>
         <button id="manual-training-btn">Manuell träning</button>
-        <div class="auto-training-controls">
-          <label for="epochs-input">
-            Epoker
-            <input type="number" id="epochs-input" min="1" value="50" />
-          </label>
-          <label for="batch-input">
-            Batch-storlek
-            <input type="number" id="batch-input" min="1" value="10" />
-          </label>
-          <label class="output-wrapper">
-            <input type="checkbox" id="animate-training" checked />
-            <span>Visa animationer</span>
-          </label>
-          <button id="auto-train-btn">Automatisk träning</button>
-        </div>
-        <button id="reset-weights-btn" class="secondary">
-          Återställ nätverket
+        <button id="auto-train-btn">Automatisk träning</button>
+        <label class="epochs-control" for="epochs-input">
+          Epoker
+          <input type="number" id="epochs-input" min="1" value="200" />
+        </label>
+        <label class="animation-toggle">
+          <input type="checkbox" id="animate-training" checked />
+          <span>Visa animationer</span>
+        </label>
+        <button id="reset-weights-btn" class="danger-button">
+          <span class="icon">⟲</span>
+          <span>Återställ nätverket</span>
         </button>
+      </div>
+
+      <div class="data-actions">
+        <button id="toggle-training-table">Visa träningsdata</button>
+        <button id="evaluate-training-btn">Utvärdera på träningsdata</button>
+        <button id="toggle-test-table">Visa testdata</button>
+        <button id="evaluate-test-btn">Utvärdera på testdata</button>
       </div>
 
       <div id="manual-status" class="status-text"></div>
       <div id="auto-status" class="status-text"></div>
 
       <div id="training-table-container" class="table-container hidden"></div>
-
-      <div class="test-actions">
-        <button id="toggle-test-table">Visa testdata</button>
-        <button id="evaluate-test-btn">Utvärdera på testdata</button>
-      </div>
       <div id="evaluation-result" class="status-text"></div>
       <div id="test-table-container" class="table-container hidden"></div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -260,6 +260,10 @@ button {
   font-size: 1em;
   cursor: pointer;
   transition: background 0.2s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 
 button:hover {
@@ -278,12 +282,16 @@ button:disabled {
   background: #1e874b;
 }
 
-.secondary {
-  background: #95a5a6;
+.danger-button {
+  background: #e74c3c;
 }
 
-.secondary:hover {
-  background: #7f8c8d;
+.danger-button:hover {
+  background: #c0392b;
+}
+
+.danger-button .icon {
+  font-size: 1.2em;
 }
 
 .manual-btn {
@@ -364,19 +372,12 @@ input[type="checkbox"] {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
-  justify-content: center;
-  margin-bottom: 16px;
+  justify-content: flex-start;
+  margin-bottom: 12px;
   align-items: center;
 }
 
-.auto-training-controls {
-  display: flex;
-  gap: 14px;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.auto-training-controls label {
+.epochs-control {
   display: flex;
   flex-direction: column;
   font-weight: 600;
@@ -384,12 +385,28 @@ input[type="checkbox"] {
   color: #2c3e50;
 }
 
-.auto-training-controls input {
+.epochs-control input {
   width: 120px;
   padding: 6px 8px;
   border: 1px solid #bbb;
   border-radius: 6px;
   font-size: 1em;
+}
+
+.animation-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.data-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  justify-content: flex-start;
+  margin-bottom: 16px;
 }
 
 .status-text {
@@ -442,14 +459,6 @@ table.data-table tbody tr:nth-child(odd) {
 
 table.data-table tbody tr:hover {
   background: #edf5ff;
-}
-
-.test-actions {
-  margin-top: 24px;
-  display: flex;
-  gap: 16px;
-  justify-content: center;
-  flex-wrap: wrap;
 }
 
 /* ---------- Animationer ---------- */


### PR DESCRIPTION
## Summary
- Omstrukturerade träningskontrollerna så att manuell/autoträning, epokfält (200 som standard), animationsval och en röd återställningsknapp med ikon ligger på samma rad.
- Lagt till en separat rad för datahantering med ny utvärderingsknapp för träningsdata och uppdaterat logiken så att endast ett datatabell kan visas åt gången.
- Satt batch-storleken till 1 i den automatiska träningsloopen och uppdaterade stilar för de nya kontrollerna.

## Testing
- Not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e4b4a896a0832b8354ede4be63a3f9