### PR TITLE
Adjust manual training status placement and evaluation displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,9 @@
             </button>
             <div id="manual-example-info"></div>
           </div>
-          <div class="manual-cell manual-center"></div>
+          <div class="manual-cell manual-center">
+            <div id="manual-status" class="status-text"></div>
+          </div>
           <div class="manual-cell manual-right">
             <button id="backprop-btn" class="manual-btn manual-btn-backprop">
               Bakåtpropagering
@@ -161,19 +163,26 @@
         </button>
       </div>
 
-      <div class="data-actions">
-        <button id="toggle-training-table">Visa träningsdata</button>
-        <button id="evaluate-training-btn">Utvärdera på träningsdata</button>
-        <button id="toggle-test-table">Visa testdata</button>
-        <button id="evaluate-test-btn">Utvärdera på testdata</button>
+      <div class="data-sections">
+        <div class="data-section">
+          <div class="data-buttons">
+            <button id="toggle-training-table">Visa träningsdata</button>
+            <button id="evaluate-training-btn">Utvärdera på träningsdata</button>
+          </div>
+          <div id="training-evaluation" class="status-text data-status"></div>
+          <div id="training-table-container" class="table-container hidden"></div>
+        </div>
+        <div class="data-section">
+          <div class="data-buttons">
+            <button id="toggle-test-table">Visa testdata</button>
+            <button id="evaluate-test-btn">Utvärdera på testdata</button>
+          </div>
+          <div id="test-evaluation" class="status-text data-status"></div>
+          <div id="test-table-container" class="table-container hidden"></div>
+        </div>
       </div>
 
-      <div id="manual-status" class="status-text"></div>
       <div id="auto-status" class="status-text"></div>
-
-      <div id="training-table-container" class="table-container hidden"></div>
-      <div id="evaluation-result" class="status-text"></div>
-      <div id="test-table-container" class="table-container hidden"></div>
     </section>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -161,7 +161,8 @@ const evaluateTrainingBtn = document.getElementById('evaluate-training-btn');
 const toggleTestBtn = document.getElementById('toggle-test-table');
 const testTableContainer = document.getElementById('test-table-container');
 const evaluateTestBtn = document.getElementById('evaluate-test-btn');
-const evaluationResult = document.getElementById('evaluation-result');
+const trainingEvaluation = document.getElementById('training-evaluation');
+const testEvaluation = document.getElementById('test-evaluation');
 
 const ihLines = [];
 const hoLines = [];
@@ -796,12 +797,6 @@ async function handleBackprop() {
     }
   }
 
-  manualFeedback.textContent += ` (fel=${round2(
-    Math.abs(
-      manualForwardCache.forward.output -
-        LABEL_TO_TARGET[manualForwardCache.example.label]
-    )
-  )})`;
   manualForwardCache = null;
   manualActiveExample = null;
   updateManualStatus(
@@ -863,7 +858,7 @@ async function runAutoTraining() {
 }
 
 /***** Utvärdering *****/
-function evaluateDataset(data, label) {
+function evaluateDataset(data, targetEl) {
   let totalError = 0;
   let correct = 0;
   data.forEach((example) => {
@@ -876,13 +871,13 @@ function evaluateDataset(data, label) {
   });
   const mse = totalError / data.length;
   const accuracy = (correct / data.length) * 100;
-  evaluationResult.textContent = `Utvärdering (${label}): Medelkvadratiskt fel: ${round2(
+  targetEl.textContent = `Medelkvadratiskt fel: ${round2(
     mse
   )} – Träffsäkerhet: ${round2(accuracy)} %`;
 }
 
-const evaluateTrainingSet = () => evaluateDataset(trainingData, 'Träning');
-const evaluateTestSet = () => evaluateDataset(testData, 'Test');
+const evaluateTrainingSet = () => evaluateDataset(trainingData, trainingEvaluation);
+const evaluateTestSet = () => evaluateDataset(testData, testEvaluation);
 
 /***** Återställning *****/
 function resetNetwork() {
@@ -897,7 +892,8 @@ function resetNetwork() {
   manualStatus.textContent = manualMode
     ? `Nästa exempel i kön: ${trainingData[manualPointer].id}`
     : '';
-  evaluationResult.textContent = '';
+  trainingEvaluation.textContent = '';
+  testEvaluation.textContent = '';
   autoStatus.textContent = '';
   resetHiddenDisplays();
   updateBiasLabels();

--- a/styles.css
+++ b/styles.css
@@ -401,18 +401,35 @@ input[type="checkbox"] {
   color: #2c3e50;
 }
 
-.data-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 14px;
-  justify-content: flex-start;
-  margin-bottom: 16px;
-}
-
 .status-text {
   text-align: center;
   color: #2c3e50;
   min-height: 24px;
+}
+
+.data-sections {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: flex-start;
+  margin-bottom: 16px;
+}
+
+.data-section {
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.data-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.data-status {
+  text-align: left;
 }
 
 .table-container {


### PR DESCRIPTION
## Summary
- move the manual training status into the manual controls between the load and backprop buttons
- separate the training and test evaluation outputs with left-aligned text and keep the data tables beneath them
- remove the manual error suffix and refresh styling to support the new layout

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4b904dc54832baf154e2cd8f54ce2