### PR TITLE
Adjust training panel layout and auto training controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,9 +122,9 @@
     </div>
 
     <section id="manual-training-panel">
-      <div id="manual-controls" class="manual-controls hidden">
+      <div id="manual-controls" class="manual-controls manual-inactive">
         <div class="manual-grid">
-          <div class="manual-cell manual-left">
+          <div class="manual-cell manual-left manual-only">
             <button id="load-next-example" class="manual-btn manual-btn-next">
               Ladda nästa exempel
             </button>
@@ -133,7 +133,7 @@
           <div class="manual-cell manual-center">
             <div id="manual-status" class="status-text"></div>
           </div>
-          <div class="manual-cell manual-right">
+          <div class="manual-cell manual-right manual-only">
             <button id="backprop-btn" class="manual-btn manual-btn-backprop">
               Bakåtpropagering
             </button>
@@ -147,20 +147,24 @@
       <h2>Träningsområde</h2>
 
       <div class="training-actions">
-        <button id="manual-training-btn">Manuell träning</button>
-        <button id="auto-train-btn">Automatisk träning</button>
-        <label class="epochs-control" for="epochs-input">
-          Epoker
-          <input type="number" id="epochs-input" min="1" value="200" />
-        </label>
-        <label class="animation-toggle">
-          <input type="checkbox" id="animate-training" checked />
-          <span>Visa animationer</span>
-        </label>
-        <button id="reset-weights-btn" class="danger-button">
-          <span class="icon">⟲</span>
-          <span>Återställ nätverket</span>
-        </button>
+        <div class="training-row primary-actions">
+          <button id="manual-training-btn">Manuell träning</button>
+          <button id="reset-weights-btn" class="danger-button">
+            <span class="icon">⟲</span>
+            <span>Återställ nätverket</span>
+          </button>
+        </div>
+        <div class="training-row secondary-actions">
+          <button id="auto-train-btn">Automatisk träning</button>
+          <label class="epochs-control" for="epochs-input">
+            Epoker
+            <input type="number" id="epochs-input" min="1" value="200" />
+          </label>
+          <label class="animation-toggle">
+            <input type="checkbox" id="animate-training" checked />
+            <span>Visa animationer</span>
+          </label>
+        </div>
       </div>
 
       <div class="data-sections">
@@ -182,7 +186,6 @@
         </div>
       </div>
 
-      <div id="auto-status" class="status-text"></div>
     </section>
 
     <script src="script.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -72,8 +72,18 @@ h1 {
   padding: 0 24px 10px;
 }
 
+
 .manual-controls {
   width: 100%;
+}
+
+.manual-controls.manual-inactive .manual-only {
+  display: none;
+}
+
+.manual-controls.manual-inactive .manual-grid {
+  grid-template-columns: minmax(0, 1fr);
+  justify-items: center;
 }
 
 .manual-grid {
@@ -370,11 +380,24 @@ input[type="checkbox"] {
 
 .training-actions {
   display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.training-row {
+  display: flex;
   flex-wrap: wrap;
   gap: 14px;
-  justify-content: flex-start;
-  margin-bottom: 12px;
   align-items: center;
+}
+
+.training-row.primary-actions {
+  justify-content: flex-start;
+}
+
+.training-row.secondary-actions {
+  justify-content: flex-start;
 }
 
 .epochs-control {
@@ -405,6 +428,14 @@ input[type="checkbox"] {
   text-align: center;
   color: #2c3e50;
   min-height: 24px;
+}
+
+.button-muted {
+  opacity: 0.55;
+}
+
+.button-muted:hover {
+  opacity: 0.55;
 }
 
 .data-sections {


### PR DESCRIPTION
## Summary
- reorganize the training area so manual/reset controls sit on the first row, secondary controls on the second, and data buttons below
- keep the shared training status output in the manual panel while muting buttons when conflicting modes are active
- allow animated automatic training to be stopped after the current epoch and update button labels accordingly

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4bcdaf9c8832ba0cfe5a08d234f5c