### PR TITLE
Omstrukturera layouten för nätverket och kontrollpanelerna

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,125 +7,138 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <h1>Neuralt nätverk för bevattning</h1>
+    <section id="network-area">
+      <h1>Neuralt nätverk för bevattning</h1>
 
-    <div id="network-container">
-      <!-- ---------- Indatalager ---------- -->
-      <div id="input-layer" class="layer">
-        <h2 class="layer-title">Inmatningslager</h2>
-        <div class="node-stack">
-          <div class="input-node" id="input0">
-            <label
-              >Jordfuktighet (%)
-              <input type="number" id="moisture" value="30" step="1" />
-            </label>
-          </div>
-          <div class="input-node" id="input1">
-            <label
-              >Lufttemperatur (°C)
-              <input type="number" id="temperature" value="20" step="1" />
-            </label>
+      <div id="network-container">
+        <!-- ---------- Indatalager ---------- -->
+        <div id="input-layer" class="layer">
+          <h2 class="layer-title">Inmatningslager</h2>
+          <div class="node-stack">
+            <div class="input-node" id="input0">
+              <label
+                >Jordfuktighet (%)
+                <input type="number" id="moisture" value="30" step="1" />
+              </label>
+            </div>
+            <div class="input-node" id="input1">
+              <label
+                >Lufttemperatur (°C)
+                <input type="number" id="temperature" value="20" step="1" />
+              </label>
+            </div>
           </div>
         </div>
 
+        <!-- ---------- Dolt lager ---------- -->
+        <div id="hidden-layer" class="layer">
+          <h2 class="layer-title">Dolt lager</h2>
+          <div class="node-stack">
+            <div class="hidden-node" id="hidden0">
+              <div class="bias-label bias-hidden" id="bias-h0">?</div>
+              <div class="node-part pre" id="pre-h0">?</div>
+              <div class="node-part relu">
+                <svg viewBox="0 0 40 40">
+                  <path
+                    d="M5 20H20L35 5"
+                    stroke="#fff"
+                    stroke-width="4"
+                    fill="none"
+                  />
+                </svg>
+              </div>
+              <div class="node-part post" id="post-h0">?</div>
+            </div>
+
+            <div class="hidden-node" id="hidden1">
+              <div class="bias-label bias-hidden" id="bias-h1">?</div>
+              <div class="node-part pre" id="pre-h1">?</div>
+              <div class="node-part relu">
+                <svg viewBox="0 0 40 40">
+                  <path
+                    d="M5 20H20L35 5"
+                    stroke="#fff"
+                    stroke-width="4"
+                    fill="none"
+                  />
+                </svg>
+              </div>
+              <div class="node-part post" id="post-h1">?</div>
+            </div>
+
+            <div class="hidden-node" id="hidden2">
+              <div class="bias-label bias-hidden" id="bias-h2">?</div>
+              <div class="node-part pre" id="pre-h2">?</div>
+              <div class="node-part relu">
+                <svg viewBox="0 0 40 40">
+                  <path
+                    d="M5 20H20L35 5"
+                    stroke="#fff"
+                    stroke-width="4"
+                    fill="none"
+                  />
+                </svg>
+              </div>
+              <div class="node-part post" id="post-h2">?</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ---------- Outputlager ---------- -->
+        <div id="output-layer" class="layer">
+          <h2 class="layer-title">Utmatningslager</h2>
+          <p class="layer-info">Bevattningen startas om värdet är positivt (&gt;0)</p>
+          <div class="node-stack">
+            <div class="output-wrapper">
+              <div class="output-node" id="output-node">
+                <div class="bias-label bias-output" id="bias-o">?</div>
+                <div id="output-prob">?</div>
+              </div>
+            </div>
+          </div>
+          <div id="prediction-text">Bevattning startas: ?</div>
+        </div>
+
+        <!-- ---------- SVG för linjer ---------- -->
+        <svg id="connections" class="connections-svg"></svg>
       </div>
+    </section>
 
-      <!-- ---------- Dolt lager ---------- -->
-      <div id="hidden-layer" class="layer">
-        <h2 class="layer-title">Dolt lager</h2>
-        <div class="node-stack">
-          <div class="hidden-node" id="hidden0">
-            <div class="bias-label bias-hidden" id="bias-h0">?</div>
-            <div class="node-part pre" id="pre-h0">?</div>
-            <div class="node-part relu">
-              <svg viewBox="0 0 40 40">
-                <path
-                  d="M5 20H20L35 5"
-                  stroke="#fff"
-                  stroke-width="4"
-                  fill="none"
-                />
-              </svg>
+    <section id="calculation-area">
+      <div class="calculation-grid">
+        <div class="calc-group">
+          <h2 class="calc-title">Beräkningar</h2>
+          <div class="calc-controls">
+            <button id="calc-hidden">Beräkna lager</button>
+            <div class="calc-select">
+              <label for="show-ih">Visa kopplingar</label>
+              <select id="show-ih">
+                <option value="none">Ingen</option>
+                <option value="all">Alla</option>
+                <option value="h0">Nod 1</option>
+                <option value="h1">Nod 2</option>
+                <option value="h2">Nod 3</option>
+              </select>
             </div>
-            <div class="node-part post" id="post-h0">?</div>
           </div>
-
-          <div class="hidden-node" id="hidden1">
-            <div class="bias-label bias-hidden" id="bias-h1">?</div>
-            <div class="node-part pre" id="pre-h1">?</div>
-            <div class="node-part relu">
-              <svg viewBox="0 0 40 40">
-                <path
-                  d="M5 20H20L35 5"
-                  stroke="#fff"
-                  stroke-width="4"
-                  fill="none"
-                />
-              </svg>
-            </div>
-            <div class="node-part post" id="post-h1">?</div>
-          </div>
-
-          <div class="hidden-node" id="hidden2">
-            <div class="bias-label bias-hidden" id="bias-h2">?</div>
-            <div class="node-part pre" id="pre-h2">?</div>
-            <div class="node-part relu">
-              <svg viewBox="0 0 40 40">
-                <path
-                  d="M5 20H20L35 5"
-                  stroke="#fff"
-                  stroke-width="4"
-                  fill="none"
-                />
-              </svg>
-            </div>
-            <div class="node-part post" id="post-h2">?</div>
-          </div>
+          <div id="ih-calculation" class="calculation-output"></div>
         </div>
-
-        <div class="controls">
-          <button id="calc-hidden">Beräkna lager</button>
-          <select id="show-ih">
-            <option value="none">Ingen</option>
-            <option value="all">Alla</option>
-            <option value="h0">Nod 1</option>
-            <option value="h1">Nod 2</option>
-            <option value="h2">Nod 3</option>
-          </select>
+        <div class="calc-group calc-group-right">
+          <h2 class="calc-title">Utmaningsnoden</h2>
+          <div class="calc-controls">
+            <button id="calc-output">Beräkna nod</button>
+            <label class="toggle-option"
+              ><input type="checkbox" id="show-ho" /> Visa kopplingar</label
+            >
+            <label class="toggle-option"
+              ><input type="checkbox" id="show-calculations" /> Visa
+              beräkningar</label
+            >
+          </div>
+          <div id="ho-calculation" class="calculation-output"></div>
         </div>
-        <div id="ih-calculation" class="calculation-output"></div>
       </div>
-
-      <!-- ---------- Outputlager ---------- -->
-      <div id="output-layer" class="layer">
-        <h2 class="layer-title">Utmatningslager</h2>
-        <p class="layer-info">Bevattningen startas om värdet är positivt (&gt;0)</p>
-        <div class="node-stack">
-          <div class="output-wrapper">
-            <div class="output-node" id="output-node">
-              <div class="bias-label bias-output" id="bias-o">?</div>
-              <div id="output-prob">?</div>
-            </div>
-          </div>
-        </div>
-        <div id="prediction-text">Bevattning startas: ?</div>
-
-        <div class="controls">
-          <button id="calc-output">Beräkna nod</button>
-          <label style="display: flex; align-items: center; gap: 6px"
-            ><input type="checkbox" id="show-ho" /> Visa kopplingar</label
-          >
-          <label style="display: flex; align-items: center; gap: 6px"
-            ><input type="checkbox" id="show-calculations" /> Visa
-            beräkningar</label
-          >
-        </div>
-        <div id="ho-calculation" class="calculation-output"></div>
-      </div>
-
-      <!-- ---------- SVG för linjer ---------- -->
-      <svg id="connections" class="connections-svg"></svg>
-    </div>
+    </section>
 
     <section id="manual-training-panel">
       <div id="manual-controls" class="manual-controls manual-inactive">

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,22 @@ h1 {
   margin-top: 0;
 }
 
+#network-area {
+  max-width: 1500px;
+  margin: 0 auto 24px;
+  padding: 24px 24px 10px;
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+#network-area h1 {
+  margin-bottom: 0;
+}
+
 /* ---------- Lagerlayout ---------- */
 .layer-title {
   font-size: 1.1em;
@@ -40,10 +56,10 @@ h1 {
   justify-content: center;
   align-items: stretch;
   gap: clamp(80px, 12vw, 180px);
-  margin: 30px auto 40px;
+  margin: 0 auto 10px;
   position: relative;
-  max-width: 1500px;
-  padding: 20px 10px;
+  max-width: 1400px;
+  padding: 10px;
   min-height: 460px;
 }
 
@@ -75,6 +91,10 @@ h1 {
 
 .manual-controls {
   width: 100%;
+}
+
+.manual-controls.manual-inactive {
+  display: none;
 }
 
 .manual-controls.manual-inactive .manual-only {
@@ -252,22 +272,13 @@ h1 {
   animation: biasForwardPulse 0.8s ease-in-out;
 }
 
-/* ---------- Kontroller ---------- */
-.controls {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-  margin-top: 22px;
-}
-
 .calculation-output {
   min-height: 22px;
   font-size: 0.9em;
   line-height: 1.5;
-  text-align: center;
+  text-align: left;
   color: #2c3e50;
-  max-width: 260px;
+  max-width: 100%;
 }
 
 .calculation-output.calc-hidden {
@@ -304,6 +315,80 @@ h1 {
 
 .calc-result-output {
   color: #f5b7b1;
+}
+
+#calculation-area {
+  max-width: 1100px;
+  margin: 0 auto 30px;
+  background: #ffffff;
+  padding: 28px;
+  border-radius: 16px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+}
+
+.calculation-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 26px;
+  align-items: stretch;
+  justify-content: space-between;
+}
+
+.calc-group {
+  flex: 1 1 320px;
+  background: linear-gradient(135deg, #f8fbff, #eef6ff);
+  border-radius: 14px;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: inset 0 0 0 1px rgba(52, 152, 219, 0.12);
+}
+
+.calc-group-right {
+  background: linear-gradient(135deg, #fff7f6, #ffeceb);
+  box-shadow: inset 0 0 0 1px rgba(231, 76, 60, 0.15);
+}
+
+.calc-title {
+  margin: 0;
+  font-size: 1.15em;
+  font-weight: 700;
+  color: #2c3e50;
+}
+
+.calc-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+}
+
+.calc-select {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.calc-select select {
+  min-width: 150px;
+}
+
+.calc-select label {
+  font-size: 0.95em;
+}
+
+.toggle-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.calc-group-right .calculation-output {
+  text-align: right;
+  margin-left: auto;
 }
 
 button {
@@ -543,6 +628,29 @@ input[type="checkbox"] {
 }
 
 @media (max-width: 900px) {
+  #network-area {
+    padding: 20px 18px 6px;
+  }
+
+  #network-container {
+    flex-direction: column;
+    align-items: center;
+    gap: 40px;
+  }
+
+  .calculation-grid {
+    flex-direction: column;
+  }
+
+  .calc-group {
+    flex: 1 1 auto;
+  }
+
+  .calc-group-right .calculation-output {
+    text-align: left;
+    margin-left: 0;
+  }
+
   .data-sections {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary
- omslut nätverksvisualiseringen i ett eget område tillsammans med rubrikerna
- flytta beräkningskontrollerna till en ny sektion med separata grupper för lager- och utgångsberäkningar
- gör panelen för manuell träning tom tills läget aktiveras och justera stilar för den nya layouten

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4cd1186b4832b8988d1da787b5073