### PR TITLE
Flytta manuell träningspanel och uppdatera rubriker

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 
         <!-- ---------- Dolt lager ---------- -->
         <div id="hidden-layer" class="layer">
-          <h2 class="layer-title">Dolt lager</h2>
+          <h2 class="layer-title">Det dolda lagret</h2>
           <div class="node-stack">
             <div class="hidden-node" id="hidden0">
               <div class="bias-label bias-hidden" id="bias-h0">?</div>
@@ -86,7 +86,7 @@
 
         <!-- ---------- Outputlager ---------- -->
         <div id="output-layer" class="layer">
-          <h2 class="layer-title">Utmatningslager</h2>
+          <h2 class="layer-title">Utmatningslagret</h2>
           <p class="layer-info">Bevattningen startas om värdet är positivt (&gt;0)</p>
           <div class="node-stack">
             <div class="output-wrapper">
@@ -104,7 +104,30 @@
       </div>
     </section>
 
+    <section id="manual-training-panel">
+      <div id="manual-controls" class="manual-controls manual-inactive">
+        <div class="manual-grid">
+          <div class="manual-cell manual-left manual-only">
+            <button id="load-next-example" class="manual-btn manual-btn-next">
+              Ladda nästa exempel
+            </button>
+            <div id="manual-example-info"></div>
+          </div>
+          <div class="manual-cell manual-center">
+            <div id="manual-status" class="status-text"></div>
+          </div>
+          <div class="manual-cell manual-right manual-only">
+            <button id="backprop-btn" class="manual-btn manual-btn-backprop">
+              Bakåtpropagering
+            </button>
+            <div id="manual-feedback"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section id="calculation-area">
+      <h2 class="section-heading">Beräkningsområde</h2>
       <div class="calculation-grid">
         <div class="calc-group">
           <h2 class="calc-title">Beräkningar</h2>
@@ -136,28 +159,6 @@
             >
           </div>
           <div id="ho-calculation" class="calculation-output"></div>
-        </div>
-      </div>
-    </section>
-
-    <section id="manual-training-panel">
-      <div id="manual-controls" class="manual-controls manual-inactive">
-        <div class="manual-grid">
-          <div class="manual-cell manual-left manual-only">
-            <button id="load-next-example" class="manual-btn manual-btn-next">
-              Ladda nästa exempel
-            </button>
-            <div id="manual-example-info"></div>
-          </div>
-          <div class="manual-cell manual-center">
-            <div id="manual-status" class="status-text"></div>
-          </div>
-          <div class="manual-cell manual-right manual-only">
-            <button id="backprop-btn" class="manual-btn manual-btn-backprop">
-              Bakåtpropagering
-            </button>
-            <div id="manual-feedback"></div>
-          </div>
         </div>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -83,18 +83,20 @@ h1 {
 }
 
 #manual-training-panel {
-  max-width: 1500px;
-  margin: 0 auto 26px;
-  padding: 0 24px 10px;
+  max-width: 1100px;
+  margin: 0 auto 30px;
+  background: #ffffff;
+  padding: 28px;
+  border-radius: 16px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
 }
-
 
 .manual-controls {
   width: 100%;
 }
 
 .manual-controls.manual-inactive {
-  display: none;
+  display: block;
 }
 
 .manual-controls.manual-inactive .manual-only {
@@ -104,6 +106,8 @@ h1 {
 .manual-controls.manual-inactive .manual-grid {
   grid-template-columns: minmax(0, 1fr);
   justify-items: center;
+  margin: 0 auto;
+  max-width: 520px;
 }
 
 .manual-grid {
@@ -131,6 +135,14 @@ h1 {
 .manual-right {
   align-items: flex-end;
   text-align: right;
+}
+
+.section-heading {
+  text-align: center;
+  margin: 0 0 24px;
+  font-size: 1.4em;
+  font-weight: 700;
+  color: #2c3e50;
 }
 
 .manual-controls #manual-example-info {


### PR DESCRIPTION
## Summary
- flyttade panelen för manuell träning så att den visas mellan nätverksvisualiseringen och beräkningsområdet
- lade till rubriken "Beräkningsområde" och uppdaterade lagernamn till "Det dolda lagret" respektive "Utmatningslagret"
- justerade stilarna så att panelen för manuell träning alltid visar statusuppdateringar centrerat även vid automatisk träning

## Testing
- not run (statiskt projekt)


------
https://chatgpt.com/codex/tasks/task_e_68e4d0401b3c832bb6830c812b66142a