### PR TITLE
Align output node with hidden layer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -165,7 +165,7 @@ h1 {
 
 #output-layer .node-stack {
   justify-content: center;
-  padding-top: 40px;
+  padding-top: 0;
 }
 
 /* ---------- SVG-ytan för linjer ---------- */


### PR DESCRIPTION
## Summary
- adjust the output layer node stack spacing so the output node lines up with the middle hidden node

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4da4183e4832b9f785516d35d92f5