### PR TITLE
Align manual training feedback with displayed prediction

### DIFF
--- a/script.js
+++ b/script.js
@@ -835,17 +835,18 @@ async function runManualForward(example) {
   updatePrediction(displayForward.actHidden);
   await manualWait(350);
 
-  const predicted = LABEL_FROM_OUTPUT(modelForward.output);
+  const predictedDisplay = LABEL_FROM_OUTPUT(displayForward.output);
   const target = example.label;
   manualFeedback.textContent =
-    predicted === target
-      ? `Rätt! Nätverket förutsåg ${predicted}.`
-      : `Fel! Förväntat ${target}, men nätverket gav ${predicted}.`;
+    predictedDisplay === target
+      ? `Rätt! Nätverket förutsåg ${predictedDisplay}.`
+      : `Fel! Förväntat ${target}, men nätverket gav ${predictedDisplay}.`;
   manualFeedback.classList.add(
-    predicted === target ? 'result-correct' : 'result-wrong'
+    predictedDisplay === target ? 'result-correct' : 'result-wrong'
   );
   manualForwardCache = {
     forward: modelForward,
+    display: displayForward,
     example
   };
   manualActiveExample = example;


### PR DESCRIPTION
## Summary
- base the manual training feedback messaging on the display forward pass prediction
- store the display forward pass in the manual cache alongside the model forward pass for potential logging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5039af904832bb189652255b7798e