### PR TITLE
Förenkla visning av neuronberäkning i IH-rutan

### DIFF
--- a/script.js
+++ b/script.js
@@ -619,22 +619,15 @@ function updateIHCalculation() {
     return;
   }
   const idx = Number(currentIHSelection.slice(1));
-  const [rawMoisture, rawTemperature] = getRawInputs();
   const [x0, x1] = getModelInputs();
   const w0 = params.W_IH[0][idx];
   const w1 = params.W_IH[1][idx];
   const bias = params.B_H[idx];
   const sum = x0 * w0 + x1 * w1 + bias;
-  const html = `Rå indata: ${formatCalcSpan(
-    rawMoisture,
-    'calc-input'
-  )}, ${formatCalcSpan(rawTemperature, 'calc-input')}<br/>Normaliserat: ${formatCalcSpan(
+  const html = `${formatCalcSpan(w0, 'calc-weight')} * ${formatCalcSpan(
     x0,
     'calc-input'
-  )}, ${formatCalcSpan(x1, 'calc-input')}<br/>${formatCalcSpan(
-    w0,
-    'calc-weight'
-  )} * ${formatCalcSpan(x0, 'calc-input')} + ${formatCalcSpan(
+  )} + ${formatCalcSpan(
     w1,
     'calc-weight'
   )} * ${formatCalcSpan(x1, 'calc-input')} + ${formatCalcSpan(


### PR DESCRIPTION
### Motivation
- Minska visuellt brus i beräkningsrutan för en vald hidden-neuron genom att ta bort raden som visar råa indata och etiketten "Normaliserat:" och enbart visa själva beräkningsuttrycket baserat på normaliserade värden, vikter och bias.

### Description
- Uppdaterade `updateIHCalculation()` i `script.js` så att funktionen inte längre inkluderar `Rå indata` eller etiketten `Normaliserat:` och istället bygger HTML enbart som viktad summa: `w0 * x0 + w1 * x1 + bias = sum` med normaliserade indata visade via `formatCalcSpan`.

### Testing
- Verifierade via `rg` att strängarna `Rå indata` och `Normaliserat:` inte längre genereras i `updateIHCalculation`, och gjorde en commit av `script.js`; start av en enkel `python3 -m http.server` lyckades men ett försök att ta en UI-screenshot med Playwright misslyckades på grund av browser-krasch (SIGSEGV), så visuell screenshot-validering kunde inte slutföras.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43365a914832b935b9628c85744d9)